### PR TITLE
Fix search result book name attribute error

### DIFF
--- a/app/parsers/book_parser.py
+++ b/app/parsers/book_parser.py
@@ -131,7 +131,7 @@ class BookParser:
         soup = BeautifulSoup(html, "html.parser")
 
         # 获取书籍标题
-        title_selector = self.book_rule.get("title", "")
+        title_selector = self.book_rule.get("name", "")
         title = self._extract_text(soup, title_selector)
 
         # 获取作者

--- a/rules/rule-20.json
+++ b/rules/rule-20.json
@@ -9,22 +9,22 @@
     "url": "https://www.wxsy.net/search.html",
     "method": "post",
     "data": "{s: %s}",
-    "result": "body > div.container > div:nth-child(1) > div > ul > li",
-    "bookName": "span.s2 > a",
+    "list": "body > div.container > div:nth-child(1) > div > ul > li",
+    "name": "span.s2 > a",
     "author": "span.s3 > a",
     "category": "span.s1",
-    "latestChapter": "span.s4 > a",
-    "lastUpdateTime": "span.s5"
+    "latest_chapter": "span.s4 > a",
+    "update_time": "span.s5"
   },
   "book": {
     "url": "https://www.wxsy.net/novel/(.*?)/",
-    "bookName": "meta[property=\"og:novel:book_name\"]",
+    "name": "meta[property=\"og:novel:book_name\"]",
     "author": "meta[property=\"og:novel:author\"]",
     "intro": "meta[name=\"description\"]",
     "category": "meta[property=\"og:novel:category\"]",
-    "coverUrl": "meta[property=\"og:image\"]",
-    "latestChapter": "meta[property=\"og:novel:latest_chapter_name\"]",
-    "lastUpdateTime": "meta[property=\"og:novel:update_time\"]",
+    "cover": "meta[property=\"og:image\"]",
+    "latest_chapter": "meta[property=\"og:novel:latest_chapter_name\"]",
+    "update_time": "meta[property=\"og:novel:update_time\"]",
     "status": "meta[property=\"og:novel:status\"]"
   },
   "toc": {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes `SearchResult` object missing `bookName` attribute by standardizing field names in `rule-20.json` and `book_parser.py`.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The error stemmed from a mismatch where `rule-20.json` used `bookName` while the search parser expected `name`. Additionally, the `book_parser.py` was looking for `title` for the book name, while other rule files consistently used `name`. This PR aligns all these field names (`bookName` -> `name`, `result` -> `list`, `latestChapter` -> `latest_chapter`, `lastUpdateTime` -> `update_time`, `coverUrl` -> `cover`) and corrects the book parser to use `name`, resolving the attribute error and improving consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-e0014a14-84c9-4f2e-b8f7-f9cd7abcbbbf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e0014a14-84c9-4f2e-b8f7-f9cd7abcbbbf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>