### PR TITLE
Fix search result book name attribute error

### DIFF
--- a/app/models/book.py
+++ b/app/models/book.py
@@ -16,3 +16,8 @@ class Book(BaseModel):
     toc_url: str = ""
     source_id: int = 0
     source_name: str = ""
+
+    @property
+    def bookName(self) -> str:
+        """向后兼容的属性，映射到title字段"""
+        return self.title

--- a/app/models/search.py
+++ b/app/models/search.py
@@ -20,6 +20,11 @@ class SearchResult(BaseModel):
     source_name: str = ""
     score: float = 0.0
 
+    @property
+    def bookName(self) -> str:
+        """向后兼容的属性，映射到title字段"""
+        return self.title
+
 
 class SearchResponse(BaseModel):
     """搜索响应模型"""


### PR DESCRIPTION
Add `bookName` property to `SearchResult` and `Book` models to resolve `AttributeError` when accessing `bookName` instead of `title`.

The `SearchResult` and `Book` models previously only had a `title` attribute. This change introduces a `bookName` property that maps to the existing `title` attribute, providing backward compatibility for code that expects a `bookName` attribute.

---
<a href="https://cursor.com/background-agent?bcId=bc-dfde5afd-db9a-4348-bc5d-18ea0d1ba03d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dfde5afd-db9a-4348-bc5d-18ea0d1ba03d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>