### PR TITLE
Investigate and clear workflow cache

### DIFF
--- a/app/models/book.py
+++ b/app/models/book.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class Book(BaseModel):
@@ -16,8 +16,15 @@ class Book(BaseModel):
     toc_url: str = ""
     source_id: int = 0
     source_name: str = ""
+    bookName: str = Field(default="", alias="bookName")
+
+    def __init__(self, **data):
+        super().__init__(**data)
+        # 确保bookName字段与title保持同步
+        if not self.bookName and self.title:
+            self.bookName = self.title
 
     @property
-    def bookName(self) -> str:
+    def bookName_property(self) -> str:
         """向后兼容的属性，映射到title字段"""
         return self.title

--- a/app/models/search.py
+++ b/app/models/search.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class SearchResult(BaseModel):
@@ -19,9 +19,16 @@ class SearchResult(BaseModel):
     source_id: int = 0
     source_name: str = ""
     score: float = 0.0
+    bookName: str = Field(default="", alias="bookName")
+
+    def __init__(self, **data):
+        super().__init__(**data)
+        # 确保bookName字段与title保持同步
+        if not self.bookName and self.title:
+            self.bookName = self.title
 
     @property
-    def bookName(self) -> str:
+    def bookName_property(self) -> str:
         """向后兼容的属性，映射到title字段"""
         return self.title
 


### PR DESCRIPTION
Refactor `bookName` from a property to a field in `SearchResult` and `Book` models to resolve serialization errors.

The `'SearchResult' object has no attribute 'bookName'` error occurred because Pydantic models, when serialized, might not correctly expose `@property` decorated attributes. By converting `bookName` to a standard `Field` and ensuring its synchronization with `title` via `__init__`, we guarantee its presence and correct serialization. A `bookName_property` was added for backward compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-cf109e15-6a38-4438-b615-0778ea6c02fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cf109e15-6a38-4438-b615-0778ea6c02fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>