### PR TITLE
Debug search failure: missing bookName attribute

### DIFF
--- a/app/models/book.py
+++ b/app/models/book.py
@@ -16,7 +16,7 @@ class Book(BaseModel):
     toc_url: str = ""
     source_id: int = 0
     source_name: str = ""
-    bookName: str = Field(default="", alias="bookName")
+    bookName: str = Field(default="", description="书名，与title字段同步")
 
     def __init__(self, **data):
         super().__init__(**data)
@@ -28,3 +28,11 @@ class Book(BaseModel):
     def bookName_property(self) -> str:
         """向后兼容的属性，映射到title字段"""
         return self.title
+
+    def model_dump(self, **kwargs):
+        """自定义序列化方法，确保bookName字段正确输出"""
+        data = super().model_dump(**kwargs)
+        # 确保bookName字段存在且与title同步
+        if not data.get('bookName') and data.get('title'):
+            data['bookName'] = data['title']
+        return data

--- a/app/models/search.py
+++ b/app/models/search.py
@@ -19,7 +19,7 @@ class SearchResult(BaseModel):
     source_id: int = 0
     source_name: str = ""
     score: float = 0.0
-    bookName: str = Field(default="", alias="bookName")
+    bookName: str = Field(default="", description="书名，与title字段同步")
 
     def __init__(self, **data):
         super().__init__(**data)
@@ -31,6 +31,14 @@ class SearchResult(BaseModel):
     def bookName_property(self) -> str:
         """向后兼容的属性，映射到title字段"""
         return self.title
+
+    def model_dump(self, **kwargs):
+        """自定义序列化方法，确保bookName字段正确输出"""
+        data = super().model_dump(**kwargs)
+        # 确保bookName字段存在且与title同步
+        if not data.get('bookName') and data.get('title'):
+            data['bookName'] = data['title']
+        return data
 
 
 class SearchResponse(BaseModel):

--- a/test_search_result.py
+++ b/test_search_result.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""
+测试SearchResult模型是否能正常工作
+"""
+
+import sys
+import os
+
+# 添加项目根目录到Python路径
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+try:
+    from app.models.search import SearchResult, SearchResponse
+    
+    # 测试创建SearchResult对象
+    result = SearchResult(
+        title="测试小说",
+        author="测试作者",
+        intro="测试简介",
+        url="http://example.com",
+        source_id=1,
+        source_name="测试书源"
+    )
+    
+    print("✓ SearchResult对象创建成功")
+    print(f"  title: {result.title}")
+    print(f"  bookName: {result.bookName}")
+    print(f"  author: {result.author}")
+    
+    # 测试序列化
+    data = result.model_dump()
+    print("✓ 序列化成功")
+    print(f"  序列化数据: {data}")
+    
+    # 测试SearchResponse
+    response = SearchResponse(
+        code=200,
+        message="success",
+        data=[result]
+    )
+    
+    print("✓ SearchResponse对象创建成功")
+    
+    # 测试响应序列化
+    response_data = response.model_dump()
+    print("✓ 响应序列化成功")
+    print(f"  响应数据: {response_data}")
+    
+    print("\n✅ 所有测试通过！SearchResult模型工作正常")
+    
+except Exception as e:
+    print(f"❌ 测试失败: {str(e)}")
+    import traceback
+    traceback.print_exc()


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes `SearchResult` and `Book` models to correctly handle the `bookName` attribute during serialization.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The error `'SearchResult' object has no attribute 'bookName'` occurred because Pydantic v2's `Field` alias behavior changed, preventing direct attribute access. This PR removes the problematic `alias` and adds a custom `model_dump` method to ensure `bookName` is properly populated from the `title` field for backward compatibility during serialization. A new test file is added to verify the fix.

---
<a href="https://cursor.com/background-agent?bcId=bc-9c2b0a4e-7f0a-47d8-94fc-b607b9d98e59">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9c2b0a4e-7f0a-47d8-94fc-b607b9d98e59">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>