### PR TITLE
Handle gateway timeout download error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
       - ./downloads:/var/www/novel/downloads:ro
     depends_on:
-      - novel
+      - novel-api
     networks:
       - novel-network
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,70 @@
+worker_processes auto;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+
+    sendfile        on;
+    tcp_nopush      on;
+    tcp_nodelay     on;
+
+    keepalive_timeout  65;
+    client_max_body_size 0;
+
+    # Gzip
+    gzip on;
+    gzip_comp_level 5;
+    gzip_min_length 1024;
+    gzip_proxied any;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+    upstream novel_api_upstream {
+        server novel-api:8000;
+        keepalive 32;
+    }
+
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      close;
+    }
+
+    server {
+        listen 80;
+        server_name _;
+
+        # General proxy settings
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection "";
+
+        proxy_connect_timeout 60s;
+        proxy_send_timeout    600s;
+        proxy_read_timeout    600s;  # Allow long downloads
+        send_timeout          600s;
+
+        # Default proxy to API
+        location / {
+            proxy_pass http://novel_api_upstream;
+        }
+
+        # Downloads can stream for a long time; disable buffering
+        location /api/novels/download {
+            proxy_pass http://novel_api_upstream;
+            proxy_buffering off;
+            proxy_request_buffering off;
+            proxy_cache off;
+        }
+
+        # Optional: health check passthrough
+        location = /health {
+            proxy_pass http://novel_api_upstream/;
+        }
+    }
+}


### PR DESCRIPTION
Increase Nginx proxy timeouts and disable buffering for the download endpoint, and fix docker-compose dependency.

The 504 Gateway Timeout errors were caused by Nginx timing out while waiting for the backend service to generate large files for download. These changes prevent Nginx from prematurely closing the connection.

---
<a href="https://cursor.com/background-agent?bcId=bc-a7c4b735-f6d4-4c9d-9b41-f574ac58e833">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a7c4b735-f6d4-4c9d-9b41-f574ac58e833">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

