### PR TITLE
Distinguish book source URLs for scraping

### DIFF
--- a/rules/rule-05.json
+++ b/rules/rule-05.json
@@ -12,6 +12,11 @@
     "list": "body > div.wrap > div > div > div",
     "name": "dl > dt > a",
     "author": "dl > dt > span",
+    "detail_url": "dl > dt > a",
+    "url_transform": {
+      "from_domain": "www.sososhu.com",
+      "to_domain": "www.tianxibook.com"
+    },
     "category": "",
     "latest": "",
     "update": "",


### PR DESCRIPTION
Separate search URL from article detail URL for Source 5 and add domain transformation.

Source 5 uses an external search engine, so search results contain links to the search domain. This change ensures the extracted article detail URLs are correctly transformed to point to the actual content source for downloading.

---
<a href="https://cursor.com/background-agent?bcId=bc-2f774d02-c01e-4cb8-808a-564adb032b35">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2f774d02-c01e-4cb8-808a-564adb032b35">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

