### PR TITLE
Debug file download attribute error

### DIFF
--- a/app/core/enhanced_crawler.py
+++ b/app/core/enhanced_crawler.py
@@ -509,7 +509,7 @@ class EnhancedCrawler:
         from app.utils.epub_generator import EPUBGenerator
 
         # 生成安全的文件名
-        safe_filename = FileUtils.get_safe_filename(f"{book.title}_{book.author}")
+        safe_filename = FileUtils.sanitize_filename(f"{book.title}_{book.author}")
         epub_path = download_dir / f"{safe_filename}.epub"
 
         def generate_epub():


### PR DESCRIPTION
Fix `FileUtils` method call to use `sanitize_filename` instead of non-existent `get_safe_filename`.

---
<a href="https://cursor.com/background-agent?bcId=bc-31c09ac0-be0c-4b6b-a987-44a589e32b04">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-31c09ac0-be0c-4b6b-a987-44a589e32b04">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

